### PR TITLE
feat(ssl-vhost): make the ssl redirect configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ variables are optional and defined as follows:
 * ``serveralias``: Alias or alternative name for the host
 * ``documentroot``: Main document tree
 * ``redirect_ssl``: Redirect to SSL enabled vhost
+* ``redirect_ssl_vhost``: Redirect to this enabled vhost
 * ``options``: Vhost apache options that override the default options of the
   global variable ``apache_options``
 * ``serveradmin``: Email address of server admin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,8 @@ apache_vhosts:
     documentroot: '/var/www/html'
     # # redirect to SSL enabled vhost below (optional)
     # redirect_ssl: false
+    # If you don't have an listen_ip configured, you can manually set the vhost to redirect to here
+    #redirect_ssl_vhost: 'https://example.com'
     # # vhost options, override 'apache_options' (optional)
     # options: '+FollowSymLinks'
     # add directives not covered by any variables

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -15,7 +15,11 @@
   DocumentRoot "{{ vhost.documentroot }}"
 {% endif %}
 {% if vhost.redirect_ssl | default(false) %}
+{% if vhost.redirect_ssl_vhost is defined %}
+  Redirect permanent / {{ vhost.redirect_ssl_vhost }}
+{% else %}
   Redirect permanent / https://{{ apache_listen_ip }}:{{ apache_listen_port_ssl }}
+{% endif %}
 {% endif %}
 {% if vhost.documentroot is defined %}
   <Directory "{{ vhost.documentroot }}">


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change adds an other variable to configure where to redirect a vhost to
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/fujexo/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.3 (default, May 11 2019, 00:38:04) [GCC 9.1.1 20190503 (Red Hat 9.1.1-1)]

```
