### PR TITLE
Update installation.yml

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -8,7 +8,5 @@
 
 - name: install apache related packages
   package:
+    name: "{{ apache_packages + apache_additional_packages }}"
     state: present
-  loop:
-    - '{{ apache_packages }}'
-    - '{{ apache_additional_packages }}'


### PR DESCRIPTION
name parameter is required. currently there is nothing installed but even if required ansible is not failing. ???
see: https://docs.ansible.com/ansible/latest/modules/package_module.html

additionally:
  - omit looping, maybe looping was added to support repo installation via package. but such things should be splitted in different (pre-)tasks then.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
